### PR TITLE
Minor fix of "--cfg-options" for supporting list indexing

### DIFF
--- a/vis4d/config/config.py
+++ b/vis4d/config/config.py
@@ -191,8 +191,10 @@ def keylist_update(  # type: ignore
         if new_key:
             my_dict[cur_key] = value
         else:
-            # Type casting based on leaf node.
+            # Type casting based on the field to be replaced.
             to_type = type(my_dict[cur_key])
+            if to_type == bool:
+                value = value.lower() in ("true", "t", "1")
             my_dict[cur_key] = to_type(value)
         return
     keylist_update(my_dict[cur_key], key_list, value)

--- a/vis4d/config/config_test.py
+++ b/vis4d/config/config_test.py
@@ -39,10 +39,16 @@ class TestLoadConfig(unittest.TestCase):
 
     def test_list_replacemnet(self) -> None:
         """Check cmd line argument parsing to launch cfg."""
+        cfg_options = [
+            "train.0.name=trainer-test",
+            "train.1.cache_as_binary=false",
+            "launch.samples_per_gpu=4",
+        ]
         args = Namespace(
             config=get_test_file("config-det.toml"),
-            cfg_options="train.1.name=test,launch.samples_per_gpu=4",
+            cfg_options=",".join(cfg_options),
         )
         cfg = parse_config(args)
-        self.assertEqual(cfg.train[1]["name"], "test")
-        self.assertEqual(type(cfg.launch.samples_per_gpu), int)
+        self.assertEqual(cfg.train[0]["name"], "trainer-test")
+        self.assertEqual(cfg.train[1]["cache_as_binary"], False)
+        self.assertEqual(cfg.launch.samples_per_gpu, 4)

--- a/vis4d/config/testcases/config-det.toml
+++ b/vis4d/config/testcases/config-det.toml
@@ -6,6 +6,8 @@ samples_per_gpu = 2
 
 [[train]]
 name = "trainer-1"
+cache_as_binary = true
 
 [[train]]
 name = "trainer-2"
+cache_as_binary = true


### PR DESCRIPTION
This PR fixes a minor issue of the `--cfg-options` argument. The program throws an error of `list indices must be integers or slices not str` if someone modifies items inside a list via "--cfg-options". With this PR, we will be able to set through list indexing. It will also support the typecasting based on the type of field that will be replaced.

**Example:**  
```bash
python -m vis4d.... --cfg-options "train.0.sample_mapper.skip_empty_samples=false"
```
will be translated to following code that modifies config file.
```python
train[0].sample_mapper.skip_empty_samples = False
```